### PR TITLE
Make Rust native API JNI/FFM agnostic

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/jni/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/jni/src/api.rs
@@ -26,9 +26,10 @@
 //!   single thread (node startup/shutdown).
 //! - `create_global_runtime` / `close_global_runtime` are not thread-safe for the
 //!   same pointer.
-//! - `execute_query_blocking` is safe to call concurrently with different shard/runtime
-//!   pointers.
-//! - `stream_get_schema`, `stream_next_blocking`, `stream_close` must NOT be called
+//! - `execute_query`: async. Safe to call concurrently with different shard/runtime pointers.
+//!   The bridge layer wraps with `block_on` or `spawn`.
+//! - `stream_next`: async. The bridge layer wraps with `block_on` or `spawn`.
+//! - `stream_get_schema`, `stream_close` must NOT be called
 //!   concurrently on the same stream pointer.
 //!
 //! # FFM bridge example
@@ -98,17 +99,16 @@
 //!     let plan_bytes = unsafe {
 //!         std::slice::from_raw_parts(plan_ptr, plan_len as usize)
 //!     };
-//!     unsafe {
-//!         api::execute_query_blocking(shard_view_ptr, table_name, plan_bytes, runtime_ptr, manager)
-//!             .unwrap_or(0)
-//!     }
+//!     manager.io_runtime.block_on(unsafe {
+//!         api::execute_query(shard_view_ptr, table_name, plan_bytes, runtime_ptr, manager)
+//!     }).unwrap_or(0)
 //! }
 //!
 //! /// Get next batch. Returns FFI_ArrowArray pointer, 0 for end-of-stream, -1 on error.
 //! #[no_mangle]
 //! pub extern "C" fn df_stream_next(stream_ptr: i64) -> i64 {
 //!     let manager = RUNTIME_MANAGER.get().expect("not initialized");
-//!     unsafe { api::stream_next_blocking(stream_ptr, manager).unwrap_or(-1) }
+//!     manager.io_runtime.block_on(unsafe { api::stream_next(stream_ptr) }).unwrap_or(-1)
 //! }
 //!
 //! /// Close a stream. Safe with 0.
@@ -282,14 +282,15 @@ pub unsafe fn close_reader(ptr: i64) {
 // Query execution
 // ---------------------------------------------------------------------------
 
-/// Executes a query synchronously (blocks until the stream pointer is ready).
-///
-/// Returns a heap-allocated pointer (as i64) to the result stream.
+/// Executes a query. Returns a heap-allocated pointer (as i64) to the result stream.
 /// Caller must call `stream_close` exactly once to free it.
+///
+/// This is an async function — the bridge layer decides how to run it
+/// (`block_on` for synchronous JNI, `spawn` for async delivery).
 ///
 /// # Safety
 /// `shard_view_ptr` and `runtime_ptr` must be valid, non-zero pointers.
-pub unsafe fn execute_query_blocking(
+pub async unsafe fn execute_query(
     shard_view_ptr: i64,
     table_name: &str,
     plan_bytes: &[u8],
@@ -303,16 +304,15 @@ pub unsafe fn execute_query_blocking(
     let object_metas = shard_view.object_metas.clone();
     let cpu_executor = manager.cpu_executor();
 
-    let result = manager.io_runtime.block_on(
-        crate::query_executor::execute_query(
-            table_path,
-            object_metas,
-            table_name.to_string(),
-            plan_bytes.to_vec(),
-            runtime,
-            cpu_executor,
-        )
-    )?;
+    let result = crate::query_executor::execute_query(
+        table_path,
+        object_metas,
+        table_name.to_string(),
+        plan_bytes.to_vec(),
+        runtime,
+        cpu_executor,
+    )
+    .await?;
 
     Ok(result)
 }
@@ -337,16 +337,17 @@ pub unsafe fn stream_get_schema(stream_ptr: i64) -> Result<i64, DataFusionError>
 ///
 /// Returns a heap-allocated FFI_ArrowArray pointer (as i64), or 0 if end-of-stream.
 ///
+/// This is an async function — the bridge layer decides how to run it.
+///
 /// # Safety
 /// `stream_ptr` must be a valid, non-zero pointer. Must not be called concurrently
 /// on the same stream.
-pub unsafe fn stream_next_blocking(
+pub async unsafe fn stream_next(
     stream_ptr: i64,
-    manager: &RuntimeManager,
 ) -> Result<i64, DataFusionError> {
     let stream = &mut *(stream_ptr as *mut RecordBatchStreamAdapter<CrossRtStream>);
 
-    let result = manager.io_runtime.block_on(stream.try_next())?;
+    let result = stream.try_next().await?;
 
     match result {
         Some(batch) => {
@@ -362,7 +363,7 @@ pub unsafe fn stream_next_blocking(
 /// Closes a result stream. Safe to call with 0 (no-op).
 ///
 /// # Safety
-/// `stream_ptr` must be 0 or a valid pointer returned by `execute_query_blocking`.
+/// `stream_ptr` must be 0 or a valid pointer returned by `execute_query`.
 pub unsafe fn stream_close(stream_ptr: i64) {
     if stream_ptr != 0 {
         let _ = Box::from_raw(stream_ptr as *mut RecordBatchStreamAdapter<CrossRtStream>);

--- a/sandbox/plugins/analytics-backend-datafusion/jni/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/jni/src/api.rs
@@ -1,0 +1,442 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Bridge-agnostic API layer.
+//!
+//! All functions in this module use plain Rust types — no JNI, no FFI-specific
+//! types. Both the current JNI bridge (`lib.rs`) and a future FFM/C bridge can
+//! call these functions directly.
+//!
+//! # Pointer contract
+//!
+//! Functions that accept `i64` pointer arguments require non-zero, valid pointers
+//! to the corresponding Rust type. The caller (bridge layer) is responsible for
+//! null-checking before calling. Functions that return `i64` return heap-allocated
+//! pointers via `Box::into_raw`; the caller owns the pointer and must call the
+//! corresponding close function exactly once.
+//!
+//! # Thread safety
+//!
+//! - `init_runtime_manager` and `shutdown_runtime_manager` must be called from a
+//!   single thread (node startup/shutdown).
+//! - `create_global_runtime` / `close_global_runtime` are not thread-safe for the
+//!   same pointer.
+//! - `execute_query_blocking` is safe to call concurrently with different shard/runtime
+//!   pointers.
+//! - `stream_get_schema`, `stream_next_blocking`, `stream_close` must NOT be called
+//!   concurrently on the same stream pointer.
+//!
+//! # FFM bridge example
+//!
+//! When migrating from JNI to JDK FFM (Foreign Function & Memory API), create an
+//! `ffi_bridge.rs` that exports `extern "C"` functions calling this API. The JNI
+//! bridge (`lib.rs`) and FFM bridge are interchangeable — only the type conversion
+//! layer differs.
+//!
+//! ```rust,ignore
+//! // ffi_bridge.rs — extern "C" bridge for JDK FFM (replaces lib.rs JNI bridge)
+//! //
+//! // Java side uses java.lang.foreign.Linker to call these functions directly.
+//! // Strings are passed as (pointer, length) pairs. Byte arrays likewise.
+//! // No JNIEnv, no JString, no GlobalRef — pure C ABI.
+//!
+//! use crate::api;
+//! use crate::runtime_manager::RuntimeManager;
+//! use std::sync::{Arc, OnceLock};
+//!
+//! static RUNTIME_MANAGER: OnceLock<Arc<RuntimeManager>> = OnceLock::new();
+//!
+//! /// Initialize the Tokio runtime manager.
+//! /// Java: MethodHandle = linker.downcallHandle(lib.find("df_init"), FunctionDescriptor.ofVoid(JAVA_INT));
+//! #[no_mangle]
+//! pub extern "C" fn df_init(cpu_threads: i32) {
+//!     RUNTIME_MANAGER.get_or_init(|| Arc::new(RuntimeManager::new(cpu_threads as usize)));
+//! }
+//!
+//! /// Create a global DataFusion runtime. Returns pointer as i64, or 0 on error.
+//! /// Java: MethodHandle = linker.downcallHandle(lib.find("df_create_runtime"),
+//! ///     FunctionDescriptor.of(JAVA_LONG, JAVA_LONG, ADDRESS, JAVA_LONG, JAVA_LONG));
+//! #[no_mangle]
+//! pub extern "C" fn df_create_runtime(
+//!     memory_limit: i64,
+//!     spill_dir_ptr: *const u8,
+//!     spill_dir_len: i64,
+//!     spill_limit: i64,
+//! ) -> i64 {
+//!     let spill_dir = unsafe {
+//!         std::str::from_utf8_unchecked(
+//!             std::slice::from_raw_parts(spill_dir_ptr, spill_dir_len as usize)
+//!         )
+//!     };
+//!     api::create_global_runtime(memory_limit, spill_dir, spill_limit).unwrap_or(0)
+//! }
+//!
+//! /// Execute a query. Returns stream pointer as i64, or 0 on error.
+//! /// Error message written to (err_buf_ptr, err_buf_len), actual length returned via err_len_out.
+//! /// Java: MethodHandle = linker.downcallHandle(lib.find("df_execute_query"),
+//! ///     FunctionDescriptor.of(JAVA_LONG, JAVA_LONG, ADDRESS, JAVA_LONG, ADDRESS, JAVA_LONG, JAVA_LONG));
+//! #[no_mangle]
+//! pub extern "C" fn df_execute_query(
+//!     shard_view_ptr: i64,
+//!     table_name_ptr: *const u8,
+//!     table_name_len: i64,
+//!     plan_ptr: *const u8,
+//!     plan_len: i64,
+//!     runtime_ptr: i64,
+//! ) -> i64 {
+//!     let manager = RUNTIME_MANAGER.get().expect("not initialized");
+//!     let table_name = unsafe {
+//!         std::str::from_utf8_unchecked(
+//!             std::slice::from_raw_parts(table_name_ptr, table_name_len as usize)
+//!         )
+//!     };
+//!     let plan_bytes = unsafe {
+//!         std::slice::from_raw_parts(plan_ptr, plan_len as usize)
+//!     };
+//!     unsafe {
+//!         api::execute_query_blocking(shard_view_ptr, table_name, plan_bytes, runtime_ptr, manager)
+//!             .unwrap_or(0)
+//!     }
+//! }
+//!
+//! /// Get next batch. Returns FFI_ArrowArray pointer, 0 for end-of-stream, -1 on error.
+//! #[no_mangle]
+//! pub extern "C" fn df_stream_next(stream_ptr: i64) -> i64 {
+//!     let manager = RUNTIME_MANAGER.get().expect("not initialized");
+//!     unsafe { api::stream_next_blocking(stream_ptr, manager).unwrap_or(-1) }
+//! }
+//!
+//! /// Close a stream. Safe with 0.
+//! #[no_mangle]
+//! pub extern "C" fn df_stream_close(stream_ptr: i64) {
+//!     unsafe { api::stream_close(stream_ptr) };
+//! }
+//!
+//! // Java side (JDK 22+):
+//! //
+//! //   try (Arena arena = Arena.ofConfined()) {
+//! //       SymbolLookup lib = SymbolLookup.libraryLookup("libopensearch_datafusion.so", arena);
+//! //       Linker linker = Linker.nativeLinker();
+//! //
+//! //       var init = linker.downcallHandle(
+//! //           lib.find("df_init").get(),
+//! //           FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT)
+//! //       );
+//! //       init.invoke(Runtime.getRuntime().availableProcessors());
+//! //
+//! //       var createRuntime = linker.downcallHandle(
+//! //           lib.find("df_create_runtime").get(),
+//! //           FunctionDescriptor.of(JAVA_LONG, JAVA_LONG, ADDRESS, JAVA_LONG, JAVA_LONG)
+//! //       );
+//! //       MemorySegment spillDir = arena.allocateFrom("/tmp/spill");
+//! //       long runtimePtr = (long) createRuntime.invoke(512_000_000L, spillDir, spillDir.byteSize(), 256_000_000L);
+//! //
+//! //       var executeQuery = linker.downcallHandle(
+//! //           lib.find("df_execute_query").get(),
+//! //           FunctionDescriptor.of(JAVA_LONG, JAVA_LONG, ADDRESS, JAVA_LONG, ADDRESS, JAVA_LONG, JAVA_LONG)
+//! //       );
+//! //       MemorySegment tableName = arena.allocateFrom("my_table");
+//! //       MemorySegment plan = arena.allocateFrom(MemoryLayout.sequenceLayout(planBytes.length, JAVA_BYTE), planBytes);
+//! //       long streamPtr = (long) executeQuery.invoke(shardViewPtr, tableName, tableName.byteSize(), plan, plan.byteSize(), runtimePtr);
+//! //   }
+//! ```
+
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow_array::{Array, StructArray};
+use arrow_array::ffi::FFI_ArrowArray;
+use arrow_schema::ffi::FFI_ArrowSchema;
+use datafusion::common::DataFusionError;
+use datafusion::datasource::listing::ListingTableUrl;
+use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
+use datafusion::execution::memory_pool::{GreedyMemoryPool, TrackConsumersPool};
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::execution::{SessionState, SessionStateBuilder};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::prelude::SessionConfig;
+use futures::TryStreamExt;
+
+use crate::cross_rt_stream::CrossRtStream;
+use crate::runtime_manager::RuntimeManager;
+use crate::util::create_object_metas;
+
+/// Opaque runtime handle returned to the caller.
+/// Contains the DataFusion RuntimeEnv and a pre-built SessionState template.
+pub struct DataFusionRuntime {
+    pub runtime_env: datafusion::execution::runtime_env::RuntimeEnv,
+    /// Pre-built session state with all default features registered.
+    /// Cloned per query to avoid re-registering functions and optimizer rules.
+    pub session_state_template: SessionState,
+}
+
+/// Opaque shard view handle returned to the caller.
+pub(crate) struct ShardView {
+    pub table_path: ListingTableUrl,
+    pub object_metas: Arc<Vec<object_store::ObjectMeta>>,
+}
+
+// ---------------------------------------------------------------------------
+// Runtime management
+// ---------------------------------------------------------------------------
+
+/// Creates a DataFusion global runtime with the given resource limits.
+///
+/// Returns a heap-allocated pointer (as i64) to `DataFusionRuntime`.
+/// Caller must call `close_global_runtime` exactly once to free it.
+pub fn create_global_runtime(
+    memory_pool_limit: i64,
+    spill_dir: &str,
+    spill_limit: i64,
+) -> Result<i64, DataFusionError> {
+    let disk_manager = DiskManagerBuilder::default()
+        .with_max_temp_directory_size(spill_limit as u64)
+        .with_mode(DiskManagerMode::Directories(vec![PathBuf::from(spill_dir)]));
+
+    let memory_pool = Arc::new(TrackConsumersPool::new(
+        GreedyMemoryPool::new(memory_pool_limit as usize),
+        NonZeroUsize::new(5).unwrap(),
+    ));
+
+    let runtime_env = RuntimeEnvBuilder::new()
+        .with_memory_pool(memory_pool)
+        .with_disk_manager_builder(disk_manager)
+        .build()?;
+
+    let mut config = SessionConfig::new();
+    config.options_mut().execution.parquet.pushdown_filters = false;
+    config.options_mut().execution.target_partitions = 4;
+    config.options_mut().execution.batch_size = 8192;
+
+    let session_state_template = SessionStateBuilder::new()
+        .with_config(config)
+        .with_runtime_env(Arc::from(runtime_env.clone()))
+        .with_default_features()
+        .build();
+
+    let runtime = DataFusionRuntime { runtime_env, session_state_template };
+    Ok(Box::into_raw(Box::new(runtime)) as i64)
+}
+
+/// Closes a DataFusion global runtime. Safe to call with 0 (no-op).
+///
+/// # Safety
+/// `ptr` must be 0 or a valid pointer returned by `create_global_runtime`.
+pub unsafe fn close_global_runtime(ptr: i64) {
+    if ptr != 0 {
+        let _ = Box::from_raw(ptr as *mut DataFusionRuntime);
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Reader management
+// ---------------------------------------------------------------------------
+
+/// Creates a native reader (ShardView) for the given path and files.
+///
+/// Returns a heap-allocated pointer (as i64) to `ShardView`.
+/// Caller must call `close_reader` exactly once to free it.
+pub fn create_reader(
+    table_path: &str,
+    mut filenames: Vec<String>,
+    manager: &RuntimeManager,
+) -> Result<i64, DataFusionError> {
+    filenames.sort();
+
+    let table_url = ListingTableUrl::parse(table_path)
+        .map_err(|e| DataFusionError::Execution(format!("Invalid table path: {}", e)))?;
+
+    // TODO: use global runtime's object store instead of building a throwaway RuntimeEnv
+    let default_rt = RuntimeEnvBuilder::new().build()?;
+    let store = default_rt.object_store(&table_url)?;
+
+    let object_metas = manager.io_runtime.block_on(
+        create_object_metas(store.as_ref(), table_path, filenames),
+    )?;
+
+    let shard_view = ShardView {
+        table_path: table_url,
+        object_metas: Arc::new(object_metas),
+    };
+    Ok(Box::into_raw(Box::new(shard_view)) as i64)
+}
+
+/// Closes a native reader. Safe to call with 0 (no-op).
+///
+/// # Safety
+/// `ptr` must be 0 or a valid pointer returned by `create_reader`.
+pub unsafe fn close_reader(ptr: i64) {
+    if ptr != 0 {
+        let _ = Box::from_raw(ptr as *mut ShardView);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Query execution
+// ---------------------------------------------------------------------------
+
+/// Executes a query synchronously (blocks until the stream pointer is ready).
+///
+/// Returns a heap-allocated pointer (as i64) to the result stream.
+/// Caller must call `stream_close` exactly once to free it.
+///
+/// # Safety
+/// `shard_view_ptr` and `runtime_ptr` must be valid, non-zero pointers.
+pub unsafe fn execute_query_blocking(
+    shard_view_ptr: i64,
+    table_name: &str,
+    plan_bytes: &[u8],
+    runtime_ptr: i64,
+    manager: &RuntimeManager,
+) -> Result<i64, DataFusionError> {
+    let shard_view = &*(shard_view_ptr as *const ShardView);
+    let runtime = &*(runtime_ptr as *const DataFusionRuntime);
+
+    let table_path = shard_view.table_path.clone();
+    let object_metas = shard_view.object_metas.clone();
+    let cpu_executor = manager.cpu_executor();
+
+    let result = manager.io_runtime.block_on(
+        crate::query_executor::execute_query(
+            table_path,
+            object_metas,
+            table_name.to_string(),
+            plan_bytes.to_vec(),
+            runtime,
+            cpu_executor,
+        )
+    )?;
+
+    Ok(result)
+}
+
+// ---------------------------------------------------------------------------
+// Stream operations
+// ---------------------------------------------------------------------------
+
+/// Returns the Arrow schema for the given stream as a heap-allocated FFI_ArrowSchema pointer.
+///
+/// # Safety
+/// `stream_ptr` must be a valid, non-zero pointer to a RecordBatchStreamAdapter.
+pub unsafe fn stream_get_schema(stream_ptr: i64) -> Result<i64, DataFusionError> {
+    let stream = &mut *(stream_ptr as *mut RecordBatchStreamAdapter<CrossRtStream>);
+    let schema = stream.schema();
+    let ffi_schema = FFI_ArrowSchema::try_from(schema.as_ref())
+        .map_err(|e| DataFusionError::Execution(format!("Schema conversion failed: {}", e)))?;
+    Ok(Box::into_raw(Box::new(ffi_schema)) as i64)
+}
+
+/// Loads the next record batch from the stream.
+///
+/// Returns a heap-allocated FFI_ArrowArray pointer (as i64), or 0 if end-of-stream.
+///
+/// # Safety
+/// `stream_ptr` must be a valid, non-zero pointer. Must not be called concurrently
+/// on the same stream.
+pub unsafe fn stream_next_blocking(
+    stream_ptr: i64,
+    manager: &RuntimeManager,
+) -> Result<i64, DataFusionError> {
+    let stream = &mut *(stream_ptr as *mut RecordBatchStreamAdapter<CrossRtStream>);
+
+    let result = manager.io_runtime.block_on(stream.try_next())?;
+
+    match result {
+        Some(batch) => {
+            let struct_array: StructArray = batch.into();
+            let array_data = struct_array.into_data();
+            let ffi_array = FFI_ArrowArray::new(&array_data);
+            Ok(Box::into_raw(Box::new(ffi_array)) as i64)
+        }
+        None => Ok(0),
+    }
+}
+
+/// Closes a result stream. Safe to call with 0 (no-op).
+///
+/// # Safety
+/// `stream_ptr` must be 0 or a valid pointer returned by `execute_query_blocking`.
+pub unsafe fn stream_close(stream_ptr: i64) {
+    if stream_ptr != 0 {
+        let _ = Box::from_raw(stream_ptr as *mut RecordBatchStreamAdapter<CrossRtStream>);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Converts SQL to Substrait plan bytes (test only).
+///
+/// # Safety
+/// `shard_view_ptr` and `runtime_ptr` must be valid, non-zero pointers.
+pub unsafe fn sql_to_substrait(
+    shard_view_ptr: i64,
+    table_name: &str,
+    sql: &str,
+    runtime_ptr: i64,
+    manager: &RuntimeManager,
+) -> Result<Vec<u8>, DataFusionError> {
+    use datafusion::datasource::listing::{ListingOptions, ListingTable, ListingTableConfig};
+    use datafusion::datasource::file_format::parquet::ParquetFormat;
+    use datafusion::execution::cache::{CacheAccessor, DefaultListFilesCache};
+    use datafusion::execution::cache::cache_manager::CacheManagerConfig;
+    use datafusion_substrait::logical_plan::producer::to_substrait_plan;
+    use prost::Message;
+
+    let shard_view = &*(shard_view_ptr as *const ShardView);
+    let runtime = &*(runtime_ptr as *const DataFusionRuntime);
+    let table_path = shard_view.table_path.clone();
+    let object_metas = shard_view.object_metas.clone();
+    let table_name = table_name.to_string();
+
+    manager.io_runtime.block_on(async {
+        let list_file_cache = Arc::new(DefaultListFilesCache::default());
+        list_file_cache.put(
+            &datafusion::execution::cache::TableScopedPath {
+                table: None,
+                path: table_path.prefix().clone(),
+            },
+            object_metas,
+        );
+        let runtime_env = RuntimeEnvBuilder::from_runtime_env(&runtime.runtime_env)
+            .with_cache_manager(
+                CacheManagerConfig::default()
+                    .with_list_files_cache(Some(list_file_cache))
+                    .with_file_metadata_cache(Some(
+                        runtime.runtime_env.cache_manager.get_file_metadata_cache(),
+                    ))
+                    .with_files_statistics_cache(
+                        runtime.runtime_env.cache_manager.get_file_statistic_cache(),
+                    ),
+            )
+            .build()?;
+
+        let state = runtime.session_state_template.clone()
+            .with_runtime_env(Arc::from(runtime_env));
+        let ctx = datafusion::prelude::SessionContext::new_with_state(state);
+
+        let listing_options = ListingOptions::new(Arc::new(ParquetFormat::new()))
+            .with_file_extension(".parquet")
+            .with_collect_stat(true);
+        let schema = listing_options.infer_schema(&ctx.state(), &table_path).await?;
+        let config = ListingTableConfig::new(table_path)
+            .with_listing_options(listing_options)
+            .with_schema(schema);
+        ctx.register_table(&table_name, Arc::new(ListingTable::try_new(config)?))?;
+
+        let plan = ctx.sql(sql).await?.logical_plan().clone();
+        let substrait = to_substrait_plan(&plan, &ctx.state())?;
+        let mut buf = Vec::new();
+        substrait.encode(&mut buf)
+            .map_err(|e| DataFusionError::Execution(format!("Substrait encode failed: {}", e)))?;
+        Ok(buf)
+    })
+}

--- a/sandbox/plugins/analytics-backend-datafusion/jni/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/jni/src/lib.rs
@@ -235,10 +235,10 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_execut
         }
     };
 
-    // Delegate to bridge-agnostic API
-    let result = unsafe {
-        api::execute_query_blocking(shard_view_ptr as i64, &table_name, &plan_bytes, runtime_ptr as i64, manager)
-    };
+    // Delegate to bridge-agnostic API — bridge does the block_on
+    let result = manager.io_runtime.block_on(unsafe {
+        api::execute_query(shard_view_ptr as i64, &table_name, &plan_bytes, runtime_ptr as i64, manager)
+    });
 
     with_jni_env(|env| match result {
         Ok(stream_ptr) => set_action_listener_ok_global(env, &listener_ref, stream_ptr as jlong),
@@ -296,7 +296,7 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_stream
         }
     };
 
-    let result = unsafe { api::stream_next_blocking(stream_ptr as i64, manager) };
+    let result = manager.io_runtime.block_on(unsafe { api::stream_next(stream_ptr as i64) });
 
     with_jni_env(|env| match result {
         Ok(array_ptr) => set_action_listener_ok_global(env, &listener_ref, array_ptr as jlong),

--- a/sandbox/plugins/analytics-backend-datafusion/jni/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/jni/src/lib.rs
@@ -5,33 +5,27 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
+
+//! JNI bridge layer.
+//!
+//! This module is a thin adapter between Java's JNI types and the bridge-agnostic
+//! API in [`api`]. All core logic lives in `api.rs` and `query_executor.rs`.
+//! When migrating to JDK FFM, replace this file with an `extern "C"` bridge
+//! that calls the same `api::*` functions.
+
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::cell::RefCell;
-use std::num::NonZeroUsize;
-use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 
-use arrow_array::StructArray;
-use arrow_array::Array;
-use arrow_schema::ffi::FFI_ArrowSchema;
-use arrow_array::ffi::FFI_ArrowArray;
 use datafusion::common::DataFusionError;
-use datafusion::datasource::listing::ListingTableUrl;
-use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
-use datafusion::execution::memory_pool::{GreedyMemoryPool, TrackConsumersPool};
-use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
-use datafusion::execution::{RecordBatchStream, SessionState, SessionStateBuilder};
-use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use datafusion::prelude::SessionConfig;
-use futures::TryStreamExt;
 use jni::objects::{JByteArray, JClass, JObject, JObjectArray, JString};
 use jni::sys::{jint, jlong};
 use jni::{JNIEnv, JavaVM};
 use log::error;
-use object_store::ObjectMeta;
 
+pub mod api;
 pub mod cross_rt_stream;
 pub mod executor;
 pub mod io;
@@ -41,7 +35,6 @@ pub mod util;
 
 use jni_macros::jni_safe;
 
-use crate::cross_rt_stream::CrossRtStream;
 use crate::runtime_manager::RuntimeManager;
 use crate::util::*;
 
@@ -70,21 +63,15 @@ where
     })
 }
 
-// Native types for runtime and reader
-
-pub struct DataFusionRuntime {
-    pub runtime_env: RuntimeEnv,
-    /// Pre-built session state with all default features registered.
-    /// Cloned per query to avoid re-registering functions and optimizer rules.
-    pub session_state_template: SessionState,
+fn get_manager() -> Result<&'static Arc<RuntimeManager>, DataFusionError> {
+    TOKIO_RUNTIME_MANAGER
+        .get()
+        .ok_or_else(|| DataFusionError::Execution("Runtime manager not initialized".to_string()))
 }
 
-struct ShardView {
-    table_path: ListingTableUrl,
-    object_metas: Arc<Vec<ObjectMeta>>,
-}
-
+// ---------------------------------------------------------------------------
 // Tokio runtime management
+// ---------------------------------------------------------------------------
 
 #[jni_safe]
 #[no_mangle]
@@ -108,7 +95,10 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_shutdo
     }
 }
 
-// Create DataFusion global runtime with user defined configuration
+// ---------------------------------------------------------------------------
+// DataFusion runtime
+// ---------------------------------------------------------------------------
+
 #[jni_safe(default = 0)]
 #[no_mangle]
 pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_createGlobalRuntime(
@@ -122,47 +112,20 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_create
     let spill_dir: String = match env.get_string(&spill_dir) {
         Ok(s) => s.into(),
         Err(e) => {
-            let _ = env.throw_new(
-                "java/lang/IllegalArgumentException",
-                format!("Invalid spill dir: {:?}", e),
-            );
+            let _ = env.throw_new("java/lang/IllegalArgumentException", format!("Invalid spill dir: {:?}", e));
             return 0;
         }
     };
 
-    let disk_manager = DiskManagerBuilder::default()
-        .with_max_temp_directory_size(spill_limit as u64)
-        .with_mode(DiskManagerMode::Directories(vec![PathBuf::from(spill_dir)]));
-
-    let memory_pool = Arc::new(TrackConsumersPool::new(
-        GreedyMemoryPool::new(memory_pool_limit as usize),
-        NonZeroUsize::new(5).unwrap(),
-    ));
-
-    let runtime_env = RuntimeEnvBuilder::new()
-        .with_memory_pool(memory_pool)
-        .with_disk_manager_builder(disk_manager)
-        .build()
-        .unwrap();
-
-    let mut config = SessionConfig::new();
-    config.options_mut().execution.parquet.pushdown_filters = false;
-    config.options_mut().execution.target_partitions = 4;
-    config.options_mut().execution.batch_size = 8192;
-
-    // TODO : config is per dynamic and reusing state across queries causes like "Table already exists"
-    // state has to be per query
-    let session_state_template = SessionStateBuilder::new()
-        .with_config(config)
-        .with_runtime_env(Arc::from(runtime_env.clone()))
-        .with_default_features()
-        .build();
-
-    let runtime = DataFusionRuntime { runtime_env, session_state_template };
-    Box::into_raw(Box::new(runtime)) as jlong
+    match api::create_global_runtime(memory_pool_limit, &spill_dir, spill_limit) {
+        Ok(ptr) => ptr as jlong,
+        Err(e) => {
+            let _ = env.throw_new("java/lang/RuntimeException", e.to_string());
+            0
+        }
+    }
 }
 
-// Close DataFusion global runtime
 #[jni_safe]
 #[no_mangle]
 pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_closeGlobalRuntime(
@@ -170,12 +133,13 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_closeG
     _class: JClass,
     ptr: jlong,
 ) {
-    if ptr != 0 {
-        let _ = unsafe { Box::from_raw(ptr as *mut DataFusionRuntime) };
-    }
+    unsafe { api::close_global_runtime(ptr as i64) };
 }
 
-// Create datafusion reader by representing it in shard view
+// ---------------------------------------------------------------------------
+// Reader management
+// ---------------------------------------------------------------------------
+
 #[jni_safe(default = 0)]
 #[no_mangle]
 pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_createDatafusionReader(
@@ -187,82 +151,32 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_create
     let table_path: String = match env.get_string(&table_path) {
         Ok(s) => s.into(),
         Err(e) => {
-            let _ = env.throw_new(
-                "java/lang/IllegalArgumentException",
-                format!("Invalid table path: {:?}", e),
-            );
+            let _ = env.throw_new("java/lang/IllegalArgumentException", format!("Invalid table path: {:?}", e));
             return 0;
         }
     };
-
-    let mut filenames = match parse_string_arr(env, files) {
+    let filenames = match parse_string_arr(env, files) {
         Ok(f) => f,
         Err(e) => {
-            let _ = env.throw_new(
-                "java/lang/IllegalArgumentException",
-                format!("Invalid file list: {}", e),
-            );
+            let _ = env.throw_new("java/lang/IllegalArgumentException", format!("Invalid file list: {}", e));
             return 0;
         }
     };
-    filenames.sort();
-
-    let manager = match TOKIO_RUNTIME_MANAGER.get() {
-        Some(m) => m,
-        None => {
-            let _ = env.throw_new(
-                "java/lang/IllegalStateException",
-                "Runtime manager not initialized",
-            );
-            return 0;
-        }
-    };
-
-    let table_url = match ListingTableUrl::parse(&table_path) {
-        Ok(u) => u,
-        Err(e) => {
-            let _ = env.throw_new(
-                "java/lang/RuntimeException",
-                format!("Invalid table path: {}", e),
-            );
-            return 0;
-        }
-    };
-
-    let default_rt = datafusion::execution::runtime_env::RuntimeEnvBuilder::new()
-        .build()
-        .unwrap();
-
-    let store = match default_rt.object_store(&table_url) {
-        Ok(s) => s,
-        Err(e) => {
-            let _ = env.throw_new(
-                "java/lang/RuntimeException",
-                format!("Failed to resolve object store: {}", e),
-            );
-            return 0;
-        }
-    };
-
-    let tp = table_path.clone();
-    let object_metas = match manager.io_runtime.block_on(
-        create_object_metas(store.as_ref(), &tp, filenames),
-    ) {
+    let manager = match get_manager() {
         Ok(m) => m,
         Err(e) => {
-            let _ = env.throw_new(
-                "java/lang/RuntimeException",
-                format!("Failed to create metadata: {}", e),
-            );
+            let _ = env.throw_new("java/lang/IllegalStateException", e.to_string());
             return 0;
         }
     };
 
-    let shard_view = ShardView {
-        table_path: table_url,
-        object_metas: Arc::new(object_metas),
-    };
-    Box::into_raw(Box::new(shard_view)) as jlong
+    match api::create_reader(&table_path, filenames, manager) {
+        Ok(ptr) => ptr as jlong,
+        Err(e) => {
+            let _ = env.throw_new("java/lang/RuntimeException", e.to_string());
+            0
+        }
+    }
 }
 
 #[jni_safe]
@@ -272,10 +186,12 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_closeD
     _class: JClass,
     ptr: jlong,
 ) {
-    if ptr != 0 {
-        let _ = unsafe { Box::from_raw(ptr as *mut ShardView) };
-    }
+    unsafe { api::close_reader(ptr as i64) };
 }
+
+// ---------------------------------------------------------------------------
+// Query execution
+// ---------------------------------------------------------------------------
 
 #[jni_safe]
 #[no_mangle]
@@ -284,18 +200,14 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_execut
     _class: JClass,
     shard_view_ptr: jlong,
     table_name: JString,
-    substrait_bytes: JObject, // byte[]
+    substrait_bytes: JObject,
     runtime_ptr: jlong,
     listener: JObject,
 ) {
-    let manager = match TOKIO_RUNTIME_MANAGER.get() {
-        Some(m) => m,
-        None => {
-            set_action_listener_error(
-                env,
-                listener,
-                &DataFusionError::Execution("Runtime manager not initialized".to_string()),
-            );
+    let manager = match get_manager() {
+        Ok(m) => m,
+        Err(e) => {
+            set_action_listener_error(env, listener, &e);
             return;
         }
     };
@@ -303,71 +215,44 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_execut
     let table_name: String = match env.get_string(&JString::from(table_name)) {
         Ok(s) => s.into(),
         Err(e) => {
-            set_action_listener_error(
-                env,
-                listener,
-                &DataFusionError::Execution(format!("Invalid table name: {}", e)),
-            );
+            set_action_listener_error(env, listener, &DataFusionError::Execution(format!("Invalid table name: {}", e)));
             return;
         }
     };
-
     let plan_bytes_obj = unsafe { JByteArray::from_raw(substrait_bytes.as_raw()) };
     let plan_bytes = match env.convert_byte_array(plan_bytes_obj) {
         Ok(b) => b,
         Err(e) => {
-            set_action_listener_error(
-                env,
-                listener,
-                &DataFusionError::Execution(format!("Failed to convert plan bytes: {}", e)),
-            );
+            set_action_listener_error(env, listener, &DataFusionError::Execution(format!("Failed to convert plan bytes: {}", e)));
             return;
         }
     };
-
     let listener_ref = match env.new_global_ref(&listener) {
         Ok(r) => r,
         Err(e) => {
-            set_action_listener_error(
-                env,
-                listener,
-                &DataFusionError::Execution(format!("Failed to create global ref: {}", e)),
-            );
+            set_action_listener_error(env, listener, &DataFusionError::Execution(format!("Failed to create global ref: {}", e)));
             return;
         }
     };
 
-    let io_runtime = manager.io_runtime.clone();
-    let cpu_executor = manager.cpu_executor();
+    // Delegate to bridge-agnostic API
+    let result = unsafe {
+        api::execute_query_blocking(shard_view_ptr as i64, &table_name, &plan_bytes, runtime_ptr as i64, manager)
+    };
 
-    let shard_view = unsafe { &*(shard_view_ptr as *const ShardView) };
-    let runtime = unsafe { &*(runtime_ptr as *const DataFusionRuntime) };
-
-    let table_path = shard_view.table_path.clone();
-    let object_metas = shard_view.object_metas.clone();
-
-    io_runtime.block_on(async move {
-        let result = query_executor::execute_query(
-            table_path,
-            object_metas,
-            table_name,
-            plan_bytes,
-            runtime,
-            cpu_executor,
-        )
-        .await;
-
-        with_jni_env(|env| match result {
-            Ok(stream_ptr) => set_action_listener_ok_global(env, &listener_ref, stream_ptr),
-            Err(e) => {
-                error!("Query execution failed: {}", e);
-                set_action_listener_error_global(env, &listener_ref, &e);
-            }
-        });
+    with_jni_env(|env| match result {
+        Ok(stream_ptr) => set_action_listener_ok_global(env, &listener_ref, stream_ptr as jlong),
+        Err(e) => {
+            error!("Query execution failed: {}", e);
+            set_action_listener_error_global(env, &listener_ref, &e);
+        }
     });
 }
 
-// Stream operations (async)
+// ---------------------------------------------------------------------------
+// Stream operations
+// ---------------------------------------------------------------------------
+
 #[jni_safe]
 #[no_mangle]
 pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_streamGetSchema(
@@ -377,32 +262,15 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_stream
     listener: JObject,
 ) {
     if stream_ptr == 0 {
-        set_action_listener_error(
-            env,
-            listener,
-            &DataFusionError::Execution("Invalid stream pointer".to_string()),
-        );
+        set_action_listener_error(env, listener, &DataFusionError::Execution("Invalid stream pointer".to_string()));
         return;
     }
-    let stream =
-        unsafe { &mut *(stream_ptr as *mut RecordBatchStreamAdapter<CrossRtStream>) };
-    let schema = stream.schema();
-    match FFI_ArrowSchema::try_from(schema.as_ref()) {
-        Ok(ffi_schema) => {
-            let schema_ptr = Box::into_raw(Box::new(ffi_schema));
-            set_action_listener_ok(env, listener, schema_ptr as jlong);
-        }
-        Err(e) => {
-            set_action_listener_error(
-                env,
-                listener,
-                &DataFusionError::Execution(format!("Schema conversion failed: {}", e)),
-            );
-        }
+    match unsafe { api::stream_get_schema(stream_ptr as i64) } {
+        Ok(schema_ptr) => set_action_listener_ok(env, listener, schema_ptr as jlong),
+        Err(e) => set_action_listener_error(env, listener, &e),
     }
 }
 
-// This method pulls the next batch of the stream
 #[jni_safe]
 #[no_mangle]
 pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_streamNext(
@@ -412,14 +280,10 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_stream
     stream_ptr: jlong,
     listener: JObject,
 ) {
-    let manager = match TOKIO_RUNTIME_MANAGER.get() {
-        Some(m) => m,
-        None => {
-            set_action_listener_error(
-                env,
-                listener,
-                &DataFusionError::Execution("Runtime manager not initialized".to_string()),
-            );
+    let manager = match get_manager() {
+        Ok(m) => m,
+        Err(e) => {
+            set_action_listener_error(env, listener, &e);
             return;
         }
     };
@@ -427,38 +291,19 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_stream
     let listener_ref = match env.new_global_ref(&listener) {
         Ok(r) => r,
         Err(e) => {
-            set_action_listener_error(
-                env,
-                listener,
-                &DataFusionError::Execution(format!("Failed to create global ref: {}", e)),
-            );
+            set_action_listener_error(env, listener, &DataFusionError::Execution(format!("Failed to create global ref: {}", e)));
             return;
         }
     };
 
-    let io_runtime = manager.io_runtime.clone();
+    let result = unsafe { api::stream_next_blocking(stream_ptr as i64, manager) };
 
-    io_runtime.block_on(async move {
-        let stream =
-            unsafe { &mut *(stream_ptr as *mut RecordBatchStreamAdapter<CrossRtStream>) };
-        let result = stream.try_next().await;
-
-        with_jni_env(|env| match result {
-            Ok(Some(batch)) => {
-                let struct_array: StructArray = batch.into();
-                let array_data = struct_array.into_data();
-                let ffi_array = FFI_ArrowArray::new(&array_data);
-                let ffi_array_ptr = Box::into_raw(Box::new(ffi_array));
-                set_action_listener_ok_global(env, &listener_ref, ffi_array_ptr as jlong);
-            }
-            Ok(None) => {
-                set_action_listener_ok_global(env, &listener_ref, 0);
-            }
-            Err(e) => {
-                error!("Stream next failed: {}", e);
-                set_action_listener_error_global(env, &listener_ref, &e);
-            }
-        });
+    with_jni_env(|env| match result {
+        Ok(array_ptr) => set_action_listener_ok_global(env, &listener_ref, array_ptr as jlong),
+        Err(e) => {
+            error!("Stream next failed: {}", e);
+            set_action_listener_error_global(env, &listener_ref, &e);
+        }
     });
 }
 
@@ -469,13 +314,13 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_stream
     _class: JClass,
     stream_ptr: jlong,
 ) {
-    if stream_ptr != 0 {
-        let _ =
-            unsafe { Box::from_raw(stream_ptr as *mut RecordBatchStreamAdapter<CrossRtStream>) };
-    }
+    unsafe { api::stream_close(stream_ptr as i64) };
 }
 
-// JNI: SQL → Substrait (test helper)
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
 #[jni_safe(default = std::ptr::null_mut())]
 #[no_mangle]
 pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_sqlToSubstrait(
@@ -486,62 +331,26 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_sqlToS
     sql: JString,
     runtime_ptr: jlong,
 ) -> jni::sys::jbyteArray {
-    use datafusion::datasource::listing::{ListingOptions, ListingTable, ListingTableConfig};
-    use datafusion::datasource::file_format::parquet::ParquetFormat;
-    use datafusion::execution::cache::{CacheAccessor, DefaultListFilesCache};
-    use datafusion::execution::cache::cache_manager::CacheManagerConfig;
-    use datafusion::execution::runtime_env::RuntimeEnvBuilder;
-    use datafusion_substrait::logical_plan::producer::to_substrait_plan;
-    use prost::Message;
-
     let manager = TOKIO_RUNTIME_MANAGER.get().expect("Runtime manager not initialized");
     let table_name: String = env.get_string(&table_name).expect("Invalid table name").into();
     let sql: String = env.get_string(&sql).expect("Invalid SQL").into();
 
-    let shard_view = unsafe { &*(shard_view_ptr as *const ShardView) };
-    let runtime = unsafe { &*(runtime_ptr as *const DataFusionRuntime) };
-    let table_path = shard_view.table_path.clone();
-    let object_metas = shard_view.object_metas.clone();
+    let result = unsafe {
+        api::sql_to_substrait(shard_view_ptr as i64, &table_name, &sql, runtime_ptr as i64, manager)
+    };
 
-    let plan_bytes = manager.io_runtime.block_on(async {
-        let list_file_cache = Arc::new(DefaultListFilesCache::default());
-        list_file_cache.put(
-            &datafusion::execution::cache::TableScopedPath { table: None, path: table_path.prefix().clone() },
-            object_metas,
-        );
-        let runtime_env = RuntimeEnvBuilder::from_runtime_env(&runtime.runtime_env)
-            .with_cache_manager(
-                CacheManagerConfig::default()
-                    .with_list_files_cache(Some(list_file_cache))
-                    .with_file_metadata_cache(Some(runtime.runtime_env.cache_manager.get_file_metadata_cache()))
-                    .with_files_statistics_cache(runtime.runtime_env.cache_manager.get_file_statistic_cache()),
-            )
-            .build().expect("runtime env");
-
-        let state = SessionStateBuilder::new()
-            .with_config(runtime.session_state_template.config().clone())
-            .with_runtime_env(Arc::from(runtime_env))
-            .with_default_features()
-            .build();
-        let ctx = datafusion::prelude::SessionContext::new_with_state(state);
-
-        let listing_options = ListingOptions::new(Arc::new(ParquetFormat::new()))
-            .with_file_extension(".parquet").with_collect_stat(true);
-        let schema = listing_options.infer_schema(&ctx.state(), &table_path).await.expect("schema");
-        let config = ListingTableConfig::new(table_path).with_listing_options(listing_options).with_schema(schema);
-        ctx.register_table(&table_name, Arc::new(ListingTable::try_new(config).expect("table"))).expect("register");
-
-        let plan = ctx.sql(&sql).await.expect("sql").logical_plan().clone();
-        let substrait = to_substrait_plan(&plan, &ctx.state()).expect("substrait");
-        let mut buf = Vec::new();
-        substrait.encode(&mut buf).expect("encode");
-        buf
-    });
-
-    env.byte_array_from_slice(&plan_bytes).expect("byte array").into_raw()
+    match result {
+        Ok(bytes) => env.byte_array_from_slice(&bytes).expect("byte array").into_raw(),
+        Err(e) => {
+            let _ = env.throw_new("java/lang/RuntimeException", e.to_string());
+            std::ptr::null_mut()
+        }
+    }
 }
 
-// Cache management
+// ---------------------------------------------------------------------------
+// Cache management (stubs)
+// ---------------------------------------------------------------------------
 
 #[jni_safe]
 #[no_mangle]
@@ -562,7 +371,7 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_cacheM
     _runtime_ptr: jlong,
     _file_paths: JObjectArray,
 ) {
-    // TODO: wire to native cache manager when cache config is passed to createGlobalRuntime
+    // TODO: wire to native cache manager
 }
 
 #[jni_safe]
@@ -573,10 +382,8 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_cacheM
     _runtime_ptr: jlong,
     _file_paths: JObjectArray,
 ) {
-    // TODO: wire to native cache manager when cache config is passed to createGlobalRuntime
+    // TODO: wire to native cache manager
 }
-
-// JNI: Logger
 
 #[jni_safe]
 #[no_mangle]

--- a/sandbox/plugins/analytics-backend-datafusion/jni/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/jni/src/query_executor.rs
@@ -29,7 +29,7 @@ use substrait::proto::Plan;
 
 use crate::cross_rt_stream::CrossRtStream;
 use crate::executor::DedicatedExecutor;
-use crate::DataFusionRuntime;
+use crate::api::DataFusionRuntime;
 
 /// Execute a vanilla parquet query: substrait plan → DataFusion → CrossRtStream.
 /// File access goes through DataFusion's registered object store.

--- a/sandbox/plugins/analytics-backend-datafusion/jni/src/util.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/jni/src/util.rs
@@ -9,6 +9,7 @@ use datafusion::error::DataFusionError;
 use jni::objects::{GlobalRef, JObject, JObjectArray, JString, JValue};
 use jni::sys::jlong;
 use jni::JNIEnv;
+use log::error;
 use object_store::ObjectMeta;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
@@ -76,79 +77,85 @@ pub async fn create_object_metas(
 }
 
 /// Call ActionListener.onResponse(Long) via JNI.
+/// Never panics — logs and returns on failure.
 pub fn set_action_listener_ok(env: &mut JNIEnv, listener: JObject, value: jlong) {
-    let boxed = env
-        .call_static_method("java/lang/Long", "valueOf", "(J)Ljava/lang/Long;", &[value.into()])
-        .expect("Long.valueOf failed");
-    env.call_method(
-        listener,
-        "onResponse",
-        "(Ljava/lang/Object;)V",
-        &[(&boxed).into()],
-    )
-    .expect("onResponse failed");
+    let Ok(boxed) = env.call_static_method(
+        "java/lang/Long", "valueOf", "(J)Ljava/lang/Long;", &[value.into()]
+    ) else {
+        error!("Failed to box Long for ActionListener.onResponse");
+        return;
+    };
+    if let Err(e) = env.call_method(
+        listener, "onResponse", "(Ljava/lang/Object;)V", &[(&boxed).into()]
+    ) {
+        error!("Failed to call ActionListener.onResponse: {}", e);
+    }
 }
 
 /// Call ActionListener.onResponse(Long) via GlobalRef.
+/// Never panics — logs and returns on failure.
 pub fn set_action_listener_ok_global(env: &mut JNIEnv, listener: &GlobalRef, value: jlong) {
-    let boxed = env
-        .call_static_method("java/lang/Long", "valueOf", "(J)Ljava/lang/Long;", &[value.into()])
-        .expect("Long.valueOf failed");
-    env.call_method(
-        listener.as_obj(),
-        "onResponse",
-        "(Ljava/lang/Object;)V",
-        &[(&boxed).into()],
-    )
-    .expect("onResponse failed");
+    let Ok(boxed) = env.call_static_method(
+        "java/lang/Long", "valueOf", "(J)Ljava/lang/Long;", &[value.into()]
+    ) else {
+        error!("Failed to box Long for ActionListener.onResponse (global)");
+        return;
+    };
+    if let Err(e) = env.call_method(
+        listener.as_obj(), "onResponse", "(Ljava/lang/Object;)V", &[(&boxed).into()]
+    ) {
+        error!("Failed to call ActionListener.onResponse (global): {}", e);
+    }
 }
 
 /// Call ActionListener.onFailure(Exception) via JNI.
+/// Never panics — logs and returns on failure.
 pub fn set_action_listener_error(
     env: &mut JNIEnv,
     listener: JObject,
     error: &DataFusionError,
 ) {
-    let msg = env
-        .new_string(error.to_string())
-        .expect("new_string failed");
-    let exception = env
-        .new_object(
-            "java/lang/RuntimeException",
-            "(Ljava/lang/String;)V",
-            &[JValue::Object(&msg)],
-        )
-        .expect("new RuntimeException failed");
-    env.call_method(
-        listener,
-        "onFailure",
-        "(Ljava/lang/Exception;)V",
-        &[JValue::Object(&exception)],
-    )
-    .expect("onFailure failed");
+    let Ok(msg) = env.new_string(error.to_string()) else {
+        log::error!("Failed to create error string for ActionListener.onFailure");
+        return;
+    };
+    let Ok(exception) = env.new_object(
+        "java/lang/RuntimeException",
+        "(Ljava/lang/String;)V",
+        &[JValue::Object(&msg)],
+    ) else {
+        log::error!("Failed to create RuntimeException for ActionListener.onFailure");
+        return;
+    };
+    if let Err(e) = env.call_method(
+        listener, "onFailure", "(Ljava/lang/Exception;)V", &[JValue::Object(&exception)]
+    ) {
+        log::error!("Failed to call ActionListener.onFailure: {}", e);
+    }
 }
 
 /// Call ActionListener.onFailure(Exception) via GlobalRef.
+/// Never panics — logs and returns on failure.
 pub fn set_action_listener_error_global(
     env: &mut JNIEnv,
     listener: &GlobalRef,
     error: &DataFusionError,
 ) {
-    let msg = env
-        .new_string(error.to_string())
-        .expect("new_string failed");
-    let exception = env
-        .new_object(
-            "java/lang/RuntimeException",
-            "(Ljava/lang/String;)V",
-            &[JValue::Object(&msg)],
-        )
-        .expect("new RuntimeException failed");
-    env.call_method(
-        listener.as_obj(),
-        "onFailure",
-        "(Ljava/lang/Exception;)V",
-        &[JValue::Object(&exception)],
-    )
-    .expect("onFailure failed");
+    let Ok(msg) = env.new_string(error.to_string()) else {
+        log::error!("Failed to create error string for ActionListener.onFailure (global)");
+        return;
+    };
+    let Ok(exception) = env.new_object(
+        "java/lang/RuntimeException",
+        "(Ljava/lang/String;)V",
+        &[JValue::Object(&msg)],
+    ) else {
+        log::error!("Failed to create RuntimeException for ActionListener.onFailure (global)");
+        return;
+    };
+    if let Err(e) = env.call_method(
+        listener.as_obj(), "onFailure", "(Ljava/lang/Exception;)V", &[JValue::Object(&exception)]
+    ) {
+        log::error!("Failed to call ActionListener.onFailure (global): {}", e);
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Extracted api.rs on the Rust side — a bridge-agnostic API layer with plain Rust types and no JNI dependencies. lib.rs is now a thin JNI adapter that converts JNI types and delegates to api::* functions. Includes a commented FFM bridge example showing how the same API would be consumed via extern "C" functions for a future JDK FFM migration.

Made all four ActionListener callback helpers in util.rs infallible. Every .expect() replaced with let Ok(...) else { error!(...); return; }. A JNI callback failure now logs and returns instead of panicking — preventing silent hangs of Java CompletableFutures.


### Related Issues
Resolves # https://github.com/opensearch-project/OpenSearch/pull/21057
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
